### PR TITLE
Support for building with exceptions disabled

### DIFF
--- a/include/yaml-cpp/dll.h
+++ b/include/yaml-cpp/dll.h
@@ -50,6 +50,14 @@
 #  endif
 #endif
 
+#ifndef YAML_CPP_NORETURN
+#  ifdef _MSC_VER
+#    define YAML_CPP_NORETURN __declspec(noreturn)
+#  else
+#    define YAML_CPP_NORETURN __attribute__ ((noreturn))
+#  endif
+#endif
+
 #ifndef YAML_CPP_DEPRECATED_EXPORT
 #  define YAML_CPP_DEPRECATED_EXPORT YAML_CPP_API YAML_CPP_DEPRECATED
 #endif

--- a/include/yaml-cpp/exceptions.h
+++ b/include/yaml-cpp/exceptions.h
@@ -15,6 +15,21 @@
 #include <string>
 
 namespace YAML {
+
+#if defined(__cpp_exceptions) || (defined(_MSC_VER) && defined(_CPPUNWIND))
+template<typename Ex, typename... Args>
+YAML_CPP_NORETURN void YAML_throw(Args&&... args) {
+	throw Ex(std::forward<Args>(args)...);
+}
+#else
+YAML_CPP_NORETURN void handle_exception(const char* what);
+
+template<typename Ex, typename... Args>
+YAML_CPP_NORETURN void YAML_throw(Args&&... args) {
+	handle_exception(Ex(std::forward<Args>(args)...).what());
+}
+#endif
+
 // error messages
 namespace ErrorMsg {
 const char* const YAML_DIRECTIVE_ARGS =

--- a/include/yaml-cpp/node/detail/impl.h
+++ b/include/yaml-cpp/node/detail/impl.h
@@ -128,7 +128,7 @@ inline node* node_data::get(const Key& key,
         return pNode;
       return nullptr;
     case NodeType::Scalar:
-      throw BadSubscript(m_mark, key);
+      YAML_throw<BadSubscript>(m_mark, key);
   }
 
   auto it = std::find_if(m_map.begin(), m_map.end(), [&](const kv_pair m) {
@@ -154,7 +154,7 @@ inline node& node_data::get(const Key& key, shared_memory_holder pMemory) {
       convert_to_map(pMemory);
       break;
     case NodeType::Scalar:
-      throw BadSubscript(m_mark, key);
+      YAML_throw<BadSubscript>(m_mark, key);
   }
 
   auto it = std::find_if(m_map.begin(), m_map.end(), [&](const kv_pair m) {
@@ -213,7 +213,7 @@ inline void node_data::force_insert(const Key& key, const Value& value,
       convert_to_map(pMemory);
       break;
     case NodeType::Scalar:
-      throw BadInsert();
+      YAML_throw<BadInsert>();
   }
 
   node& k = convert_to_node(key, pMemory);

--- a/include/yaml-cpp/node/impl.h
+++ b/include/yaml-cpp/node/impl.h
@@ -57,7 +57,7 @@ inline Node::~Node() = default;
 
 inline void Node::EnsureNodeExists() const {
   if (!m_isValid)
-    throw InvalidNode(m_invalidKey);
+    YAML_throw<InvalidNode>(m_invalidKey);
   if (!m_pNode) {
     m_pMemory.reset(new detail::memory_holder);
     m_pNode = &m_pMemory->create_node();
@@ -74,14 +74,14 @@ inline bool Node::IsDefined() const {
 
 inline Mark Node::Mark() const {
   if (!m_isValid) {
-    throw InvalidNode(m_invalidKey);
+    YAML_throw<InvalidNode>(m_invalidKey);
   }
   return m_pNode ? m_pNode->mark() : Mark::null_mark();
 }
 
 inline NodeType::value Node::Type() const {
   if (!m_isValid)
-    throw InvalidNode(m_invalidKey);
+    YAML_throw<InvalidNode>(m_invalidKey);
   return m_pNode ? m_pNode->type() : NodeType::Null;
 }
 
@@ -125,12 +125,12 @@ struct as_if<T, void> {
 
   T operator()() const {
     if (!node.m_pNode)
-      throw TypedBadConversion<T>(node.Mark());
+      YAML_throw<TypedBadConversion<T> >(node.Mark());
 
     T t;
     if (convert<T>::decode(node, t))
       return t;
-    throw TypedBadConversion<T>(node.Mark());
+    YAML_throw<TypedBadConversion<T> >(node.Mark());
   }
 };
 
@@ -143,7 +143,7 @@ struct as_if<std::string, void> {
     if (node.Type() == NodeType::Null)
       return "null";
     if (node.Type() != NodeType::Scalar)
-      throw TypedBadConversion<std::string>(node.Mark());
+      YAML_throw<TypedBadConversion<std::string> >(node.Mark());
     return node.Scalar();
   }
 };
@@ -152,7 +152,7 @@ struct as_if<std::string, void> {
 template <typename T>
 inline T Node::as() const {
   if (!m_isValid)
-    throw InvalidNode(m_invalidKey);
+    YAML_throw<InvalidNode>(m_invalidKey);
   return as_if<T, void>(*this)();
 }
 
@@ -165,13 +165,13 @@ inline T Node::as(const S& fallback) const {
 
 inline const std::string& Node::Scalar() const {
   if (!m_isValid)
-    throw InvalidNode(m_invalidKey);
+    YAML_throw<InvalidNode>(m_invalidKey);
   return m_pNode ? m_pNode->scalar() : detail::node_data::empty_scalar();
 }
 
 inline const std::string& Node::Tag() const {
   if (!m_isValid)
-    throw InvalidNode(m_invalidKey);
+    YAML_throw<InvalidNode>(m_invalidKey);
   return m_pNode ? m_pNode->tag() : detail::node_data::empty_scalar();
 }
 
@@ -182,7 +182,7 @@ inline void Node::SetTag(const std::string& tag) {
 
 inline EmitterStyle::value Node::Style() const {
   if (!m_isValid)
-    throw InvalidNode(m_invalidKey);
+    YAML_throw<InvalidNode>(m_invalidKey);
   return m_pNode ? m_pNode->style() : EmitterStyle::Default;
 }
 
@@ -194,7 +194,7 @@ inline void Node::SetStyle(EmitterStyle::value style) {
 // assignment
 inline bool Node::is(const Node& rhs) const {
   if (!m_isValid || !rhs.m_isValid)
-    throw InvalidNode(m_invalidKey);
+    YAML_throw<InvalidNode>(m_invalidKey);
   if (!m_pNode || !rhs.m_pNode)
     return false;
   return m_pNode->is(*rhs.m_pNode);
@@ -215,7 +215,7 @@ inline Node& Node::operator=(const Node& rhs) {
 
 inline void Node::reset(const YAML::Node& rhs) {
   if (!m_isValid || !rhs.m_isValid)
-    throw InvalidNode(m_invalidKey);
+    YAML_throw<InvalidNode>(m_invalidKey);
   m_pMemory = rhs.m_pMemory;
   m_pNode = rhs.m_pNode;
 }
@@ -223,7 +223,7 @@ inline void Node::reset(const YAML::Node& rhs) {
 template <typename T>
 inline void Node::Assign(const T& rhs) {
   if (!m_isValid)
-    throw InvalidNode(m_invalidKey);
+    YAML_throw<InvalidNode>(m_invalidKey);
   AssignData(convert<T>::encode(rhs));
 }
 
@@ -253,7 +253,7 @@ inline void Node::AssignData(const Node& rhs) {
 
 inline void Node::AssignNode(const Node& rhs) {
   if (!m_isValid)
-    throw InvalidNode(m_invalidKey);
+    YAML_throw<InvalidNode>(m_invalidKey);
   rhs.EnsureNodeExists();
 
   if (!m_pNode) {
@@ -270,7 +270,7 @@ inline void Node::AssignNode(const Node& rhs) {
 // size/iterator
 inline std::size_t Node::size() const {
   if (!m_isValid)
-    throw InvalidNode(m_invalidKey);
+    YAML_throw<InvalidNode>(m_invalidKey);
   return m_pNode ? m_pNode->size() : 0;
 }
 
@@ -303,7 +303,7 @@ inline iterator Node::end() {
 template <typename T>
 inline void Node::push_back(const T& rhs) {
   if (!m_isValid)
-    throw InvalidNode(m_invalidKey);
+    YAML_throw<InvalidNode>(m_invalidKey);
   push_back(Node(rhs));
 }
 

--- a/src/exp.cpp
+++ b/src/exp.cpp
@@ -21,7 +21,7 @@ unsigned ParseHex(const std::string& str, const Mark& mark) {
     else if ('0' <= ch && ch <= '9')
       digit = ch - '0';
     else
-      throw ParserException(mark, ErrorMsg::INVALID_HEX);
+      YAML_throw<ParserException>(mark, ErrorMsg::INVALID_HEX);
 
     value = (value << 4) + digit;
   }
@@ -48,7 +48,7 @@ std::string Escape(Stream& in, int codeLength) {
   if ((value >= 0xD800 && value <= 0xDFFF) || value > 0x10FFFF) {
     std::stringstream msg;
     msg << ErrorMsg::INVALID_UNICODE << value;
-    throw ParserException(in.mark(), msg.str());
+    YAML_throw<ParserException>(in.mark(), msg.str());
   }
 
   // now break it up into chars
@@ -131,7 +131,7 @@ std::string Escape(Stream& in) {
   }
 
   std::stringstream msg;
-  throw ParserException(in.mark(), std::string(ErrorMsg::INVALID_ESCAPE) + ch);
+  YAML_throw<ParserException>(in.mark(), std::string(ErrorMsg::INVALID_ESCAPE) + ch);
 }
 }  // namespace Exp
 }  // namespace YAML

--- a/src/node_data.cpp
+++ b/src/node_data.cpp
@@ -184,7 +184,7 @@ void node_data::push_back(node& node,
   }
 
   if (m_type != NodeType::Sequence)
-    throw BadPushback();
+    YAML_throw<BadPushback>();
 
   m_sequence.push_back(&node);
 }
@@ -200,7 +200,7 @@ void node_data::insert(node& key, node& value,
       convert_to_map(pMemory);
       break;
     case NodeType::Scalar:
-      throw BadSubscript(m_mark, key);
+      YAML_throw<BadSubscript>(m_mark, key);
   }
 
   insert_map_pair(key, value);
@@ -231,7 +231,7 @@ node& node_data::get(node& key, const shared_memory_holder& pMemory) {
       convert_to_map(pMemory);
       break;
     case NodeType::Scalar:
-      throw BadSubscript(m_mark, key);
+      YAML_throw<BadSubscript>(m_mark, key);
   }
 
   for (const auto& it : m_map) {

--- a/src/parse.cpp
+++ b/src/parse.cpp
@@ -32,7 +32,7 @@ Node Load(std::istream& input) {
 Node LoadFile(const std::string& filename) {
   std::ifstream fin(filename);
   if (!fin) {
-    throw BadFile(filename);
+    YAML_throw<BadFile>(filename);
   }
   return Load(fin);
 }
@@ -65,7 +65,7 @@ std::vector<Node> LoadAll(std::istream& input) {
 std::vector<Node> LoadAllFromFile(const std::string& filename) {
   std::ifstream fin(filename);
   if (!fin) {
-    throw BadFile(filename);
+    YAML_throw<BadFile>(filename);
   }
   return LoadAll(fin);
 }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -69,11 +69,11 @@ void Parser::HandleDirective(const Token& token) {
 
 void Parser::HandleYamlDirective(const Token& token) {
   if (token.params.size() != 1) {
-    throw ParserException(token.mark, ErrorMsg::YAML_DIRECTIVE_ARGS);
+    YAML_throw<ParserException>(token.mark, ErrorMsg::YAML_DIRECTIVE_ARGS);
   }
 
   if (!m_pDirectives->version.isDefault) {
-    throw ParserException(token.mark, ErrorMsg::REPEATED_YAML_DIRECTIVE);
+    YAML_throw<ParserException>(token.mark, ErrorMsg::REPEATED_YAML_DIRECTIVE);
   }
 
   std::stringstream str(token.params[0]);
@@ -86,7 +86,7 @@ void Parser::HandleYamlDirective(const Token& token) {
   }
 
   if (m_pDirectives->version.major > 1) {
-    throw ParserException(token.mark, ErrorMsg::YAML_MAJOR_VERSION);
+    YAML_throw<ParserException>(token.mark, ErrorMsg::YAML_MAJOR_VERSION);
   }
 
   m_pDirectives->version.isDefault = false;
@@ -95,12 +95,12 @@ void Parser::HandleYamlDirective(const Token& token) {
 
 void Parser::HandleTagDirective(const Token& token) {
   if (token.params.size() != 2)
-    throw ParserException(token.mark, ErrorMsg::TAG_DIRECTIVE_ARGS);
+    YAML_throw<ParserException>(token.mark, ErrorMsg::TAG_DIRECTIVE_ARGS);
 
   const std::string& handle = token.params[0];
   const std::string& prefix = token.params[1];
   if (m_pDirectives->tags.find(handle) != m_pDirectives->tags.end()) {
-    throw ParserException(token.mark, ErrorMsg::REPEATED_TAG_DIRECTIVE);
+    YAML_throw<ParserException>(token.mark, ErrorMsg::REPEATED_TAG_DIRECTIVE);
   }
 
   m_pDirectives->tags[handle] = prefix;

--- a/src/scanner.cpp
+++ b/src/scanner.cpp
@@ -170,7 +170,7 @@ void Scanner::ScanNextToken() {
   }
 
   // don't know what it is!
-  throw ParserException(INPUT.mark(), ErrorMsg::UNKNOWN_TOKEN);
+  YAML_throw<ParserException>(INPUT.mark(), ErrorMsg::UNKNOWN_TOKEN);
 }
 
 void Scanner::ScanToNextToken() {
@@ -386,6 +386,6 @@ void Scanner::ThrowParserException(const std::string& msg) const {
     const Token& token = m_tokens.front();
     mark = token.mark;
   }
-  throw ParserException(mark, msg);
+  YAML_throw<ParserException>(mark, msg);
 }
 }  // namespace YAML

--- a/src/scanscalar.cpp
+++ b/src/scanscalar.cpp
@@ -49,7 +49,7 @@ std::string ScanScalar(Stream& INPUT, ScanScalarParams& params) {
           break;
         }
         if (params.onDocIndicator == THROW) {
-          throw ParserException(INPUT.mark(), ErrorMsg::DOC_IN_SCALAR);
+          YAML_throw<ParserException>(INPUT.mark(), ErrorMsg::DOC_IN_SCALAR);
         }
       }
 
@@ -85,7 +85,7 @@ std::string ScanScalar(Stream& INPUT, ScanScalarParams& params) {
     // eof? if we're looking to eat something, then we throw
     if (!INPUT) {
       if (params.eatEnd) {
-        throw ParserException(INPUT.mark(), ErrorMsg::EOF_IN_SCALAR);
+        YAML_throw<ParserException>(INPUT.mark(), ErrorMsg::EOF_IN_SCALAR);
       }
       break;
     }
@@ -135,7 +135,7 @@ std::string ScanScalar(Stream& INPUT, ScanScalarParams& params) {
       // we check for tabs that masquerade as indentation
       if (INPUT.peek() == '\t' && INPUT.column() < params.indent &&
           params.onTabInIndentation == THROW) {
-        throw ParserException(INPUT.mark(), ErrorMsg::TAB_IN_INDENTATION);
+        YAML_throw<ParserException>(INPUT.mark(), ErrorMsg::TAB_IN_INDENTATION);
       }
 
       if (!params.eatLeadingWhitespace) {

--- a/src/scantag.cpp
+++ b/src/scantag.cpp
@@ -26,7 +26,7 @@ const std::string ScanVerbatimTag(Stream& INPUT) {
     tag += INPUT.get(n);
   }
 
-  throw ParserException(INPUT.mark(), ErrorMsg::END_OF_VERBATIM_TAG);
+  YAML_throw<ParserException>(INPUT.mark(), ErrorMsg::END_OF_VERBATIM_TAG);
 }
 
 const std::string ScanTagHandle(Stream& INPUT, bool& canBeHandle) {
@@ -37,7 +37,7 @@ const std::string ScanTagHandle(Stream& INPUT, bool& canBeHandle) {
   while (INPUT) {
     if (INPUT.peek() == Keys::Tag) {
       if (!canBeHandle)
-        throw ParserException(firstNonWordChar, ErrorMsg::CHAR_IN_TAG_HANDLE);
+        YAML_throw<ParserException>(firstNonWordChar, ErrorMsg::CHAR_IN_TAG_HANDLE);
       break;
     }
 
@@ -74,7 +74,7 @@ const std::string ScanTagSuffix(Stream& INPUT) {
   }
 
   if (tag.empty())
-    throw ParserException(INPUT.mark(), ErrorMsg::TAG_WITH_NO_SUFFIX);
+    YAML_throw<ParserException>(INPUT.mark(), ErrorMsg::TAG_WITH_NO_SUFFIX);
 
   return tag;
 }

--- a/src/scantoken.cpp
+++ b/src/scantoken.cpp
@@ -103,7 +103,7 @@ void Scanner::ScanFlowStart() {
 // FlowEnd
 void Scanner::ScanFlowEnd() {
   if (InBlockContext())
-    throw ParserException(INPUT.mark(), ErrorMsg::FLOW_END);
+    YAML_throw<ParserException>(INPUT.mark(), ErrorMsg::FLOW_END);
 
   // we might have a solo entry in the flow context
   if (InFlowContext()) {
@@ -123,7 +123,7 @@ void Scanner::ScanFlowEnd() {
   // check that it matches the start
   FLOW_MARKER flowType = (ch == Keys::FlowSeqEnd ? FLOW_SEQ : FLOW_MAP);
   if (m_flows.top() != flowType)
-    throw ParserException(mark, ErrorMsg::FLOW_END);
+    YAML_throw<ParserException>(mark, ErrorMsg::FLOW_END);
   m_flows.pop();
 
   Token::TYPE type = (flowType ? Token::FLOW_SEQ_END : Token::FLOW_MAP_END);
@@ -153,11 +153,11 @@ void Scanner::ScanFlowEntry() {
 void Scanner::ScanBlockEntry() {
   // we better be in the block context!
   if (InFlowContext())
-    throw ParserException(INPUT.mark(), ErrorMsg::BLOCK_ENTRY);
+    YAML_throw<ParserException>(INPUT.mark(), ErrorMsg::BLOCK_ENTRY);
 
   // can we put it here?
   if (!m_simpleKeyAllowed)
-    throw ParserException(INPUT.mark(), ErrorMsg::BLOCK_ENTRY);
+    YAML_throw<ParserException>(INPUT.mark(), ErrorMsg::BLOCK_ENTRY);
 
   PushIndentTo(INPUT.column(), IndentMarker::SEQ);
   m_simpleKeyAllowed = true;
@@ -174,7 +174,7 @@ void Scanner::ScanKey() {
   // handle keys differently in the block context (and manage indents)
   if (InBlockContext()) {
     if (!m_simpleKeyAllowed)
-      throw ParserException(INPUT.mark(), ErrorMsg::MAP_KEY);
+      YAML_throw<ParserException>(INPUT.mark(), ErrorMsg::MAP_KEY);
 
     PushIndentTo(INPUT.column(), IndentMarker::MAP);
   }
@@ -202,7 +202,7 @@ void Scanner::ScanValue() {
     // handle values differently in the block context (and manage indents)
     if (InBlockContext()) {
       if (!m_simpleKeyAllowed)
-        throw ParserException(INPUT.mark(), ErrorMsg::MAP_VALUE);
+        YAML_throw<ParserException>(INPUT.mark(), ErrorMsg::MAP_VALUE);
 
       PushIndentTo(INPUT.column(), IndentMarker::MAP);
     }
@@ -238,12 +238,12 @@ void Scanner::ScanAnchorOrAlias() {
 
   // we need to have read SOMETHING!
   if (name.empty())
-    throw ParserException(INPUT.mark(), alias ? ErrorMsg::ALIAS_NOT_FOUND
+    YAML_throw<ParserException>(INPUT.mark(), alias ? ErrorMsg::ALIAS_NOT_FOUND
                                               : ErrorMsg::ANCHOR_NOT_FOUND);
 
   // and needs to end correctly
   if (INPUT && !Exp::AnchorEnd().Matches(INPUT))
-    throw ParserException(INPUT.mark(), alias ? ErrorMsg::CHAR_IN_ALIAS
+    YAML_throw<ParserException>(INPUT.mark(), alias ? ErrorMsg::CHAR_IN_ALIAS
                                               : ErrorMsg::CHAR_IN_ANCHOR);
 
   // and we're done
@@ -320,7 +320,7 @@ void Scanner::ScanPlainScalar() {
 
   // finally, check and see if we ended on an illegal character
   // if(Exp::IllegalCharInScalar.Matches(INPUT))
-  //	throw ParserException(INPUT.mark(), ErrorMsg::CHAR_IN_SCALAR);
+  //	YAML_throw<ParserException>(INPUT.mark(), ErrorMsg::CHAR_IN_SCALAR);
 
   Token token(Token::PLAIN_SCALAR, mark);
   token.value = scalar;
@@ -395,7 +395,7 @@ void Scanner::ScanBlockScalar() {
       params.chomp = STRIP;
     else if (Exp::Digit().Matches(ch)) {
       if (ch == '0')
-        throw ParserException(INPUT.mark(), ErrorMsg::ZERO_INDENT_IN_BLOCK);
+        YAML_throw<ParserException>(INPUT.mark(), ErrorMsg::ZERO_INDENT_IN_BLOCK);
 
       params.indent = ch - '0';
       params.detectIndent = false;
@@ -413,7 +413,7 @@ void Scanner::ScanBlockScalar() {
 
   // if it's not a line break, then we ran into a bad character inline
   if (INPUT && !Exp::Break().Matches(INPUT))
-    throw ParserException(INPUT.mark(), ErrorMsg::CHAR_IN_BLOCK);
+    YAML_throw<ParserException>(INPUT.mark(), ErrorMsg::CHAR_IN_BLOCK);
 
   // set the initial indentation
   if (GetTopIndent() >= 0)

--- a/src/singledocparser.cpp
+++ b/src/singledocparser.cpp
@@ -169,11 +169,11 @@ void SingleDocParser::HandleBlockSequence(EventHandler& eventHandler) {
 
   while (true) {
     if (m_scanner.empty())
-      throw ParserException(m_scanner.mark(), ErrorMsg::END_OF_SEQ);
+      YAML_throw<ParserException>(m_scanner.mark(), ErrorMsg::END_OF_SEQ);
 
     Token token = m_scanner.peek();
     if (token.type != Token::BLOCK_ENTRY && token.type != Token::BLOCK_SEQ_END)
-      throw ParserException(token.mark, ErrorMsg::END_OF_SEQ);
+      YAML_throw<ParserException>(token.mark, ErrorMsg::END_OF_SEQ);
 
     m_scanner.pop();
     if (token.type == Token::BLOCK_SEQ_END)
@@ -202,7 +202,7 @@ void SingleDocParser::HandleFlowSequence(EventHandler& eventHandler) {
 
   while (true) {
     if (m_scanner.empty())
-      throw ParserException(m_scanner.mark(), ErrorMsg::END_OF_SEQ_FLOW);
+      YAML_throw<ParserException>(m_scanner.mark(), ErrorMsg::END_OF_SEQ_FLOW);
 
     // first check for end
     if (m_scanner.peek().type == Token::FLOW_SEQ_END) {
@@ -214,7 +214,7 @@ void SingleDocParser::HandleFlowSequence(EventHandler& eventHandler) {
     HandleNode(eventHandler);
 
     if (m_scanner.empty())
-      throw ParserException(m_scanner.mark(), ErrorMsg::END_OF_SEQ_FLOW);
+      YAML_throw<ParserException>(m_scanner.mark(), ErrorMsg::END_OF_SEQ_FLOW);
 
     // now eat the separator (or could be a sequence end, which we ignore - but
     // if it's neither, then it's a bad node)
@@ -222,7 +222,7 @@ void SingleDocParser::HandleFlowSequence(EventHandler& eventHandler) {
     if (token.type == Token::FLOW_ENTRY)
       m_scanner.pop();
     else if (token.type != Token::FLOW_SEQ_END)
-      throw ParserException(token.mark, ErrorMsg::END_OF_SEQ_FLOW);
+      YAML_throw<ParserException>(token.mark, ErrorMsg::END_OF_SEQ_FLOW);
   }
 
   m_pCollectionStack->PopCollectionType(CollectionType::FlowSeq);
@@ -255,12 +255,12 @@ void SingleDocParser::HandleBlockMap(EventHandler& eventHandler) {
 
   while (true) {
     if (m_scanner.empty())
-      throw ParserException(m_scanner.mark(), ErrorMsg::END_OF_MAP);
+      YAML_throw<ParserException>(m_scanner.mark(), ErrorMsg::END_OF_MAP);
 
     Token token = m_scanner.peek();
     if (token.type != Token::KEY && token.type != Token::VALUE &&
         token.type != Token::BLOCK_MAP_END)
-      throw ParserException(token.mark, ErrorMsg::END_OF_MAP);
+      YAML_throw<ParserException>(token.mark, ErrorMsg::END_OF_MAP);
 
     if (token.type == Token::BLOCK_MAP_END) {
       m_scanner.pop();
@@ -294,7 +294,7 @@ void SingleDocParser::HandleFlowMap(EventHandler& eventHandler) {
 
   while (true) {
     if (m_scanner.empty())
-      throw ParserException(m_scanner.mark(), ErrorMsg::END_OF_MAP_FLOW);
+      YAML_throw<ParserException>(m_scanner.mark(), ErrorMsg::END_OF_MAP_FLOW);
 
     Token& token = m_scanner.peek();
     const Mark mark = token.mark;
@@ -321,7 +321,7 @@ void SingleDocParser::HandleFlowMap(EventHandler& eventHandler) {
     }
 
     if (m_scanner.empty())
-      throw ParserException(m_scanner.mark(), ErrorMsg::END_OF_MAP_FLOW);
+      YAML_throw<ParserException>(m_scanner.mark(), ErrorMsg::END_OF_MAP_FLOW);
 
     // now eat the separator (or could be a map end, which we ignore - but if
     // it's neither, then it's a bad node)
@@ -329,7 +329,7 @@ void SingleDocParser::HandleFlowMap(EventHandler& eventHandler) {
     if (nextToken.type == Token::FLOW_ENTRY)
       m_scanner.pop();
     else if (nextToken.type != Token::FLOW_MAP_END)
-      throw ParserException(nextToken.mark, ErrorMsg::END_OF_MAP_FLOW);
+      YAML_throw<ParserException>(nextToken.mark, ErrorMsg::END_OF_MAP_FLOW);
   }
 
   m_pCollectionStack->PopCollectionType(CollectionType::FlowMap);
@@ -397,7 +397,7 @@ void SingleDocParser::ParseProperties(std::string& tag, anchor_t& anchor,
 void SingleDocParser::ParseTag(std::string& tag) {
   Token& token = m_scanner.peek();
   if (!tag.empty())
-    throw ParserException(token.mark, ErrorMsg::MULTIPLE_TAGS);
+    YAML_throw<ParserException>(token.mark, ErrorMsg::MULTIPLE_TAGS);
 
   Tag tagInfo(token);
   tag = tagInfo.Translate(m_directives);
@@ -407,7 +407,7 @@ void SingleDocParser::ParseTag(std::string& tag) {
 void SingleDocParser::ParseAnchor(anchor_t& anchor, std::string& anchor_name) {
   Token& token = m_scanner.peek();
   if (anchor)
-    throw ParserException(token.mark, ErrorMsg::MULTIPLE_ANCHORS);
+    YAML_throw<ParserException>(token.mark, ErrorMsg::MULTIPLE_ANCHORS);
 
   anchor_name = token.value;
   anchor = RegisterAnchor(token.value);
@@ -427,7 +427,7 @@ anchor_t SingleDocParser::LookupAnchor(const Mark& mark,
   if (it == m_anchors.end()) {
     std::stringstream ss;
     ss << ErrorMsg::UNKNOWN_ANCHOR << name;
-    throw ParserException(mark, ss.str());
+    YAML_throw<ParserException>(mark, ss.str());
   }
 
   return it->second;


### PR DESCRIPTION
1) A new macro YAML_CPP_NORETURN to annotate functions as not returning in dll.h 2) A new function YAML_throw<ExceptionType>(args...) in exception.h
   this function will throw an exception unless exceptions are disabled in the compiler,
   detected by checking the pre-defined macro __cpp_exceptions
   In this case the exception class will be instantiated, and the user-provided function
   YAML::handle_exception(const char*) will be called on the exception's what() method
3) if exceptions are disabled,and the library's user does not provide YAML::handle_exception,
   there will be a linker error
4) all other files have been changed automatedly by running the following sed commands
   sed -i "s/throw \([A-Za-z]*\)(\(.*\))/YAML_throw<\1>(\2)/g" # throw statements for non-templated exceptions
   sed -i "s/throw \(.*\)<\(.*\)>(/YAML_throw<\1<\2> >(/g" # throw statements for templated exceptions